### PR TITLE
Use requestAnimationFrame instead of timeouts, fast word wrap, bounds for concave polygons

### DIFF
--- a/src/js/topicmap.js
+++ b/src/js/topicmap.js
@@ -928,7 +928,7 @@
                                 }
                             }
 
-                            var sized = false, textCenterX = centroidX, text = node.name, fontSize = maxFont;
+                            var sized = false, textCenterX = centroidX, text = node.name, fontSize = minFont;
 
                             if (horz.length) {
                                 var vert = poly.clip([[centroidX, 0], [centroidX, height]]);

--- a/src/js/topicmap.js
+++ b/src/js/topicmap.js
@@ -964,7 +964,7 @@
                                 if (vert.length) {
                                     // todo: why is horz sometimes empty?
                                     Raphael.svg && textEl.attr('x', 0.5 * (horz[0][0] + horz[1][0]));
-                                    var wrapAttrs = wordWrap(paper, 'Verdana', horz[0][0] - horz[1][0], node.name, 0.5, maxFont, minFont, vert[0][1] - vert[1][1], textEl);
+                                    var wrapAttrs = wordWrap(paper, 'Verdana', horz[0][0] - horz[1][0], node.name, 0.25, maxFont, minFont, vert[0][1] - vert[1][1], textEl);
                                     sized = wrapAttrs.fit;
                                 }
                             }

--- a/src/js/topicmap.js
+++ b/src/js/topicmap.js
@@ -928,26 +928,41 @@
                                 }
                             }
 
-                            var sized = false, textCenterX = centroidX, text = node.name, fontSize = minFont;
+                            var textCenterX = centroidX, text = node.name, fontSize = minFont, availX, availY;
 
                             if (horz.length) {
+                                // Get the available width/height by clipping a horizontal/vertical line through
+                                //   the centroid of the polygon.
                                 var vert = poly.clip([[centroidX, 0], [centroidX, height]]);
                                 if (vert.length) {
-                                    // todo: why is horz sometimes empty?
                                     if (Raphael.svg) {
                                         textCenterX =  0.5 * (horz[0][0] + horz[1][0]);
                                     }
 
-                                    var maxWidth = Math.ceil(0.75 * (horz[0][0] - horz[1][0]));
-                                    var maxHeight = Math.ceil(0.75 * (vert[0][1] - vert[1][1]));
-                                    var wrapAttrs = wordWrap(paper, 'Verdana', maxWidth, maxHeight, node.name, maxFont, minFont);
-                                    sized = wrapAttrs.fit;
-
-                                    if (sized) {
-                                        text = wrapAttrs.text;
-                                        fontSize = wrapAttrs.fontSize;
-                                    }
+                                    availX = horz[0][0] - horz[1][0];
+                                    availY = vert[0][1] - vert[1][1];
                                 }
+                            }
+
+                            if (!availX || !availY) {
+                                // The clip trick won't work if the polygon is concave; just use the bounding box.
+                                var box = node.path.getBBox();
+                                if (!availX) {
+                                    availX = box.width
+                                }
+                                if (!availY) {
+                                    availY = box.height
+                                }
+                            }
+
+                            var maxWidth = Math.ceil(0.75 * availX);
+                            var maxHeight = Math.ceil(0.75 * availY);
+                            var wrapAttrs = wordWrap(paper, 'Verdana', maxWidth, maxHeight, node.name, maxFont, minFont);
+                            var sized = wrapAttrs.fit;
+
+                            if (sized) {
+                                text = wrapAttrs.text;
+                                fontSize = wrapAttrs.fontSize;
                             }
 
                             if (sized || !enforceLabelBounds) {

--- a/src/js/topicmap.js
+++ b/src/js/topicmap.js
@@ -938,7 +938,9 @@
                                         textCenterX =  0.5 * (horz[0][0] + horz[1][0]);
                                     }
 
-                                    var wrapAttrs = wordWrap(paper, 'Verdana', horz[0][0] - horz[1][0], node.name, 0.25, maxFont, minFont, vert[0][1] - vert[1][1]);
+                                    var maxWidth = Math.ceil(0.75 * (horz[0][0] - horz[1][0]));
+                                    var maxHeight = Math.ceil(0.75 * (vert[0][1] - vert[1][1]));
+                                    var wrapAttrs = wordWrap(paper, 'Verdana', maxWidth, maxHeight, node.name, maxFont, minFont);
                                     sized = wrapAttrs.fit;
 
                                     if (sized) {

--- a/src/js/wordwrap.js
+++ b/src/js/wordwrap.js
@@ -16,7 +16,7 @@
     function fastLineBreak(textInput, textEl, maxWidth, fontSize, minFontSize, maxHeight) {
         var bestSize = fontSize;
         var lines = fastTryTextLayout(textInput, textEl, maxWidth, maxHeight, fontSize);
-        var biggestFitting = Number.MIN_VALUE;
+        var biggestFitting = -1;
 
         if (lines.fit) {
             biggestFitting = fontSize;

--- a/src/js/wordwrap.js
+++ b/src/js/wordwrap.js
@@ -99,7 +99,7 @@
         }
     });
 
-    return function(paper, font, maxWidth, text, padPC, fontSize, minFontSize, maxHeight) {
+    return function(paper, font, maxWidth, maxHeight, text, fontSize, minFontSize) {
         var terms = text.split(' ');
 
         if (!layoutEl) {
@@ -110,17 +110,13 @@
             layoutEl.css('font-family', font);
         }
 
-        var usable = 1 - padPC;
-        var availWidth = Math.ceil(maxWidth * usable);
-        var availHeight = Math.ceil(maxHeight * usable);
-
         layoutEl.css({
-            width: availWidth
+            width: maxWidth
         }).html(terms.map(function(term){
             return '<span>' + _.escape(term) + ' </span>'
         }).join(''));
 
-        var lineAttrs = fastLineBreak(terms, layoutEl, availWidth, fontSize, minFontSize, availHeight);
+        var lineAttrs = fastLineBreak(terms, layoutEl, maxWidth, fontSize, minFontSize, maxHeight);
 
         return {
             fit: lineAttrs.fit,

--- a/src/js/wordwrap.js
+++ b/src/js/wordwrap.js
@@ -99,10 +99,11 @@
         }
     });
 
-    return function(paper, font, maxWidth, text, padPC, fontSize, minFontSize, maxHeight, textEl) {
+    return function(paper, font, maxWidth, text, padPC, fontSize, minFontSize, maxHeight) {
         var terms = text.split(' ');
 
         if (!layoutEl) {
+            // The layout element needs to be visibility: hidden not display: none so we can get clientHeight etc.
             layoutEl = $('<div>').css({ visibility: 'hidden', 'overflow-x': 'hidden', 'font-family': font}).appendTo(document.body)
         }
         else if (lastFont !== font) {
@@ -120,10 +121,6 @@
         }).join(''));
 
         var lineAttrs = fastLineBreak(terms, layoutEl, availWidth, fontSize, minFontSize, availHeight);
-
-        if (textEl) {
-            textEl.attr(lineAttrs);
-        }
 
         return {
             fit: lineAttrs.fit,

--- a/src/js/wordwrap.js
+++ b/src/js/wordwrap.js
@@ -51,7 +51,7 @@
         textEl.css('font-size', fontSize)
 
         return {
-            fit: textEl.height() < maxHeight,
+            fit: textEl[0].getBoundingClientRect().height < maxHeight,
             text: text
         }
     }
@@ -175,7 +175,7 @@
         var terms = text.split(' ');
 
         if (!layoutEl) {
-            layoutEl = $('<div>').css({ 'font-family': font, 'font-size': 40 }).hide().appendTo(document.body)
+            layoutEl = $('<div>').css({ 'font-family': font, 'font-size': 40 , 'visibility': 'hidden'}).appendTo(document.body)
             curText = text;
             curFontFamily = font;
         }

--- a/src/js/wordwrap.js
+++ b/src/js/wordwrap.js
@@ -79,9 +79,9 @@
         })
 
         var dom = textEl[0];
-        var bounds = dom.getBoundingClientRect();
+
         return {
-            fit: bounds.height < maxHeight - reserved && dom.scrollWidth <= Math.ceil(availWidth),
+            fit: dom.clientHeight <= maxHeight - reserved && dom.scrollWidth <= Math.ceil(availWidth),
             text: text
         }
     }

--- a/src/js/wordwrap.js
+++ b/src/js/wordwrap.js
@@ -69,8 +69,10 @@
     function fastTryTextLayout(text, textEl, maxWidth, padPC, fontFamily, fontSize, maxHeight) {
         textEl.css('font-size', fontSize)
 
+        var dom = textEl[0];
+        var bounds = dom.getBoundingClientRect();
         return {
-            fit: textEl[0].getBoundingClientRect().height < maxHeight,
+            fit: bounds.height < maxHeight  && dom.scrollWidth <= Math.ceil(maxWidth),
             text: text
         }
     }

--- a/src/js/wordwrap.js
+++ b/src/js/wordwrap.js
@@ -1,7 +1,7 @@
 (function (factory) {
     if (typeof define === 'function' && define.amd) {
         // We're using AMD, e.g. require.js. Register as an anonymous module.
-        define(['jquery', 'Raphael'], factory);
+        define(['jquery', 'Raphael', 'underscore'], factory);
     } else {
         // We're using plain javascript imports, namespace everything in the Autn namespace.
         (function(scope, namespace){
@@ -10,9 +10,9 @@
             }
         })(window, 'autn.vis.util');
 
-        autn.vis.util.wordWrap = factory(jQuery, Raphael);
+        autn.vis.util.wordWrap = factory(jQuery, Raphael, _);
     }
-}(function ($, Raphael) {
+}(function ($, Raphael, _) {
     function fastLineBreak(textInput, textEl, maxWidth, fontSize, minFontSize, maxHeight) {
         var bestSize = fontSize;
         var lines = fastTryTextLayout(textInput, textEl, maxWidth, maxHeight, fontSize);
@@ -37,27 +37,20 @@
                 'font-size': biggestFitting
             })
 
-            var linesWhichFit = [], yOffset, prevLine = [];
+            var text = '', yOffset, spans = textEl.children();
 
-            textEl.children().each(function(idx, el) {
-                if (yOffset && el.offsetTop !== yOffset) {
-                    if (prevLine.length) {
-                        linesWhichFit.push(prevLine.join(' '));
-                        prevLine = [];
-                    }
+            spans.each(function(idx, el) {
+                var newOffsetTop = el.offsetTop;
+                if (yOffset && newOffsetTop !== yOffset) {
+                    text += '\n'
                 }
-
-                prevLine.push(textInput[idx]);
-                yOffset = el.offsetTop;
+                text += textInput[idx] + ' ';
+                yOffset = newOffsetTop;
             })
-
-            if (prevLine.length) {
-                linesWhichFit.push(prevLine.join(' '));
-            }
 
             return {
                 fit: fit,
-                text: linesWhichFit.join('\n'),
+                text: text,
                 'font-size': bestSize
             };
         }
@@ -123,7 +116,7 @@
         layoutEl.css({
             width: availWidth
         }).html(terms.map(function(term){
-            return '<span>' + new Option(term).innerHTML + ' </span>'
+            return '<span>' + _.escape(term) + ' </span>'
         }).join(''));
 
         var lineAttrs = fastLineBreak(terms, layoutEl, availWidth, fontSize, minFontSize, availHeight);

--- a/src/js/wordwrap.js
+++ b/src/js/wordwrap.js
@@ -104,7 +104,7 @@
 
         if (!layoutEl) {
             // The layout element needs to be visibility: hidden not display: none so we can get clientHeight etc.
-            layoutEl = $('<div>').css({ visibility: 'hidden', 'overflow-x': 'hidden', 'font-family': font}).appendTo(document.body)
+            layoutEl = $('<div>').css({ visibility: 'hidden', 'overflow-x': 'hidden', 'font-family': font, 'font-weight': 'bold'}).appendTo(document.body)
         }
         else if (lastFont !== font) {
             layoutEl.css('font-family', font);

--- a/src/js/wordwrap.js
+++ b/src/js/wordwrap.js
@@ -88,16 +88,7 @@
         return low;
     }
 
-    var layoutEl, lastFont, curPaper;
-
-    Raphael.eve.on('raphael.clear', function() {
-        if (curPaper === this) {
-            if (layoutEl) {
-                layoutEl.remove();
-                layoutEl = null;
-            }
-        }
-    });
+    var layoutEl, lastFont;
 
     return function(paper, font, maxWidth, maxHeight, text, fontSize, minFontSize) {
         var terms = text.split(' ');


### PR DESCRIPTION
Use requestAnimationFrame instead of timeouts ; use HTML DOM elements to compute SVG text layout rather than working with SVG directly since it's substantially faster; fix the titles not being sized correctly for concave polygons. 