### PR TITLE
Fix scrolling due to invisible element

### DIFF
--- a/src/js/wordwrap.js
+++ b/src/js/wordwrap.js
@@ -118,7 +118,9 @@
 
         if (!layoutEl) {
             // The layout element needs to be visibility: hidden not display: none so we can get clientHeight etc.
-            layoutEl = $('<div>').css({ visibility: 'hidden', 'overflow-x': 'hidden', 'font-family': font, 'font-weight': 'bold'}).appendTo(document.body)
+            layoutEl = $('<div>').css({ visibility: 'hidden', 'overflow-x': 'hidden',
+                'position': 'absolute', left: 0, top: 0,
+                'font-family': font, 'font-weight': 'bold'}).appendTo(document.body)
         }
         else if (lastFont !== font) {
             layoutEl.css('font-family', font);


### PR DESCRIPTION
The invisible positioning element needs to be on the top-left of the screen, or it can trigger scrollbars despite being invisible.